### PR TITLE
Fix Arduino converter build error

### DIFF
--- a/src/converter/arduino.js
+++ b/src/converter/arduino.js
@@ -59,7 +59,7 @@ namespace keyboard {
         send(&prev_report);
     }
 
-    void type(uint8_t key0, uint8_t key1, uint8_t key2, uint8_t key3, uint8_t key4, uint8_t key4, uint8_t modifiers) {
+    void type(uint8_t key0, uint8_t key1, uint8_t key2, uint8_t key3, uint8_t key4, uint8_t key5, uint8_t modifiers) {
         prev_report.keys[0] = key0;
         prev_report.keys[1] = key1;
         prev_report.keys[2] = key2;


### PR DESCRIPTION
Fix a small typo in keyboard::type function to avoid following build error.

```
KeyboardMessage:45:93: error: redefinition of 'uint8_t key4'
     void type(uint8_t key0, uint8_t key1, uint8_t key2, uint8_t key3, uint8_t key4, uint8_t key4, uint8_t modifiers) {
                                                                                             ^~~~
C:\Users\reppad\AppData\Local\Temp\arduino_modified_sketch_524957\KeyboardMessage.ino:45:79: note: 'uint8_t key4' previously declared here
     void type(uint8_t key0, uint8_t key1, uint8_t key2, uint8_t key3, uint8_t key4, uint8_t key4, uint8_t modifiers) {
                                                                               ^~~~
C:\Users\reppad\AppData\Local\Temp\arduino_modified_sketch_524957\KeyboardMessage.ino: In function 'void keyboard::type(uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t)':
KeyboardMessage:51:31: error: 'key5' was not declared in this scope
         prev_report.keys[5] = key5;
                               ^~~~
C:\Users\reppad\AppData\Local\Temp\arduino_modified_sketch_524957\KeyboardMessage.ino:51:31: note: suggested alternative: 'key0'
         prev_report.keys[5] = key5;
                               ^~~~
                               key0
C:\Users\reppad\AppData\Local\Temp\arduino_modified_sketch_524957\KeyboardMessage.ino: In function 'void duckyString(const uint8_t*, size_t)':
KeyboardMessage:64:99: error: too many arguments to function 'void keyboard::type(uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t)'
         keyboard::type(pgm_read_byte_near(keys + i+1), 0, 0, 0, 0, 0, pgm_read_byte_near(keys + i));
                                                                                                   ^
C:\Users\reppad\AppData\Local\Temp\arduino_modified_sketch_524957\KeyboardMessage.ino:45:10: note: declared here
     void type(uint8_t key0, uint8_t key1, uint8_t key2, uint8_t key3, uint8_t key4, uint8_t key4, uint8_t modifiers) {
          ^~~~
```
